### PR TITLE
fix get_timeseries key to lower

### DIFF
--- a/cattledb/storage/stores.py
+++ b/cattledb/storage/stores.py
@@ -433,6 +433,7 @@ class TimeSeriesStore(object):
         assert len(metrics) > 0
         assert len(metrics[0]) > 1
         timer = time.time()
+        key = key.lower()
 
         metric_objects = [self.get_metric_object(m) for m in metrics]
 

--- a/tests/test_timeseriesstore.py
+++ b/tests/test_timeseriesstore.py
@@ -61,7 +61,7 @@ class TimeSeriesStorageTest(unittest.TestCase):
         db.timeseries.insert("sensor1", "act", d3)
         db.timeseries.insert("sensor2", "ph", d3)
 
-        r = db.timeseries.get_single_timeseries("sensor1", "act", t, t + 500*600-1)
+        r = db.timeseries.get_single_timeseries("Sensor1", "act", t, t + 500*600-1)
         a = list(r.all())
         d = list(r.aggregation("daily", "mean"))
         self.assertEqual(len(a), 500)


### PR DESCRIPTION
when get_timeries is called with an upper case id, no metric gets returned, because the key was stored in lower case